### PR TITLE
Some initial thoughts on type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ambiguous-parser
 A parser that returns a list of possibilities
+
+Inspired by [Hutton and Meijer's library][handm],
+using list to represent possible parsers.
+
+[handm]: http://www.cs.nott.ac.uk/~pszgmh/monparsing.pdf
+
+Something like this:
+```elm
+type alias Parser a =
+    String -> Result ParserFailure (List (a, String))
+```
+But `Ok []` is an [impossible state][misi]
+should we instead use [non-empty lists][nelist]?
+
+[misi]: https://www.youtube.com/watch?v=IcgmSRJHu_8
+[nelist]: http://package.elm-lang.org/packages/mgold/elm-nonempty-list/latest

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "helpful summary of your project, less than 80 characters",
+    "repository": "https://github.com/user/project.git",
+    "license": "BSD3",
+    "source-directories": [
+        "src"
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}

--- a/src/Parser.elm
+++ b/src/Parser.elm
@@ -1,0 +1,26 @@
+module Parser exposing (..)
+
+
+type alias ParserFailure =
+    String
+
+
+type alias Parser a =
+    String -> Result ParserFailure (List ( a, String ))
+
+
+char0 : Parser Char
+char0 =
+    String.uncons
+        >> Maybe.map (Ok << List.singleton)
+        >> Maybe.withDefault (Err "Empty input")
+
+
+fail : String -> Parser a
+fail =
+    always << Err
+
+
+succeed : a -> Parser a
+succeed a =
+    \input -> Ok [ ( a, input ) ]


### PR DESCRIPTION
Hutton and Meijer define three primitivate parsers
based on a list of possible parsers. I think these
are their equivalents in Elm. I;d like to add some
tests but I shoudl really be writing my talk on
randoms.